### PR TITLE
chore: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
Pin GitHub Actions to immutable SHA references for supply chain security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tightens supply-chain security by pinning `actions/checkout`; no product/runtime code is affected.
> 
> **Overview**
> Pins the CodeQL workflow’s `actions/checkout` step from the floating `v4` tag to an immutable commit SHA (`v4.1.1`) to reduce GitHub Actions supply-chain risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fee118ee657539a5090a1c88349a138f6e277cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->