### PR TITLE
chore: add cargo-deny CI workflow

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,35 @@
+name: cargo-deny
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'forgecode-fork/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'forgecode-fork/**'
+  schedule:
+    - cron: '0 9 * * 1'
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: stable


### PR DESCRIPTION
## **User description**
Adds cargo-deny CI workflow to PhenoDevOps.

PhenoDevOps has Rust code across `crates/` and `forgecode-fork/` subdirectories. The workflow runs on PRs and pushes affecting Cargo.toml, Cargo.lock, or Rust source paths.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a CI workflow; main impact is potential new PR/push failures if dependency/license/advisory checks fail.
> 
> **Overview**
> Adds a new `.github/workflows/cargo-deny.yml` workflow that runs `cargo-deny` using `EmbarkStudios/cargo-deny-action@v2` after installing the stable Rust toolchain.
> 
> The workflow triggers on manual dispatch, weekly schedule, and PRs/pushes to `main` when Rust dependency/source paths (`Cargo.toml`, `Cargo.lock`, `crates/**`, `forgecode-fork/**`) change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51116ce529e20766f66725cc39090273b040c127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add a scheduled cargo-deny check for Rust changes

### What Changed
- Adds a new CI check that runs cargo-deny on Rust-related changes in `Cargo.toml`, `Cargo.lock`, `crates/**`, and `forgecode-fork/**`
- Runs automatically on pull requests and pushes to `main`, and can also be started manually
- Also runs on a weekly schedule to catch dependency, license, or advisory issues even when no code is changing

### Impact
`✅ Earlier dependency issue detection`
`✅ Fewer unsafe Rust dependency updates reaching main`
`✅ Ongoing weekly Rust dependency checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=VNrrnH0uv6nnfZllV-MHCqCUa_jxe9UHHusUZz3a8xI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
