### PR TITLE
fix(ci): add minimal permissions blocks to remaining workflows (v2, conflict-free)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,9 @@ name: Audit Workspace
 
 
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   # ─── Cargo Bench ──────────────────────────────────────────────────────
   benchmark:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '0 9 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,9 @@ name: Generate Changelog
 
 
 
+permissions:
+  contents: write
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+
 jobs:
   # ─── Proto Lint & Breaking ─────────────────────────────────────────
   buf:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 12 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   vitepress:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   cargo-fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/gate-check.yml
+++ b/.github/workflows/gate-check.yml
@@ -8,6 +8,9 @@ name: Gate Check
 
 
 
+permissions:
+  contents: read
+
 jobs:
   gate-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   tfsec:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
 
 name: Lint
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -8,6 +8,9 @@ name: Promote Package
 
 
 
+permissions:
+  contents: write
+
 jobs:
   gate-check:
     uses: ./.github/workflows/gate-check.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ name: Publish Package
 
 
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -10,6 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   # ─── Cargo Audit ──────────────────────────────────────────────────────
   cargo-audit:

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -10,6 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -16,6 +16,9 @@ on:
       - FUNCTIONAL_REQUIREMENTS.md
       - docs/reference/SPEC_BRANCH_WORKFLOW.md
 
+permissions:
+  contents: write
+
 jobs:
   validate-specs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -10,6 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   trivy-fs:
     runs-on: ubuntu-latest

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-maintenance.yml
+++ b/.github/workflows/workflow-maintenance.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 2 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   validate-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-sync.yml
+++ b/.github/workflows/workflow-sync.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: write
+
 jobs:
   sync-workflows:
     runs-on: ubuntu-latest

--- a/.github/workflows/zap-dast.yml
+++ b/.github/workflows/zap-dast.yml
@@ -12,6 +12,9 @@ concurrency:
 
 
 
+permissions:
+  contents: read
+
 jobs:
   zap:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## **User description**
Conflict-free recreation of #180's intent. Adds top-level permissions: blocks to 25 workflows that lacked them. No merge conflict (applied cleanly to current main). SonarCloud failures are scanner-gate-only per org policy. Closes #180.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tightening with no product code changes; main risk is a workflow failing if a job needed a scope not granted at job level, but existing job overrides were preserved.
> 
> **Overview**
> Adds **explicit top-level `permissions`** to 25 GitHub Actions workflows that previously relied on the default `GITHUB_TOKEN` scope, following least-privilege defaults.
> 
> Most workflows now declare **`contents: read`** (audit, CI, scans, lint, docs, security-adjacent checks, etc.). Workflows that **commit, tag, publish, or sync** keep **`contents: write`** at the workflow level (`changelog`, `publish`, `promote`, `tag-automation`, `workflow-sync`, `spec-validation`). Existing **job-level permission overrides** (e.g. benchmark PR comments, CodeQL `security-events: write`, CI `buf` PR access) are unchanged and still apply on top of the new defaults.
> 
> This is a **CI hardening-only** change: no application code or runtime behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed268063bf1d9c88f1fcdfbfcb323d5f5cfc0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Tighten GitHub Actions access across workflow runs

### What Changed
- Added explicit read-only access to workflows that only check code, scan, lint, or validate docs
- Kept write access only for workflows that create changelogs, publish packages, tag releases, promote builds, sync workflows, or update spec files
- Preserved existing narrower job-level access where workflows already needed special permissions

### Impact
`✅ Safer CI runs`
`✅ Lower risk of accidental repo changes from automation`
`✅ Fewer workflow permission surprises`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
