### PR TITLE
ci(workflows): fix fake placeholder SHAs in SAST configs

### DIFF
--- a/agileplus-agents/.github/workflows/sast-full.yml
+++ b/agileplus-agents/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/agileplus-agents/.github/workflows/sast-quick.yml
+++ b/agileplus-agents/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/agileplus-mcp/.github/workflows/sast-full.yml
+++ b/agileplus-mcp/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/agileplus-mcp/.github/workflows/sast-quick.yml
+++ b/agileplus-mcp/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/agileplus/.github/workflows/sast-full.yml
+++ b/agileplus/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/agileplus/.github/workflows/sast-quick.yml
+++ b/agileplus/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/forgecode-fork/.github/workflows/sast-full.yml
+++ b/forgecode-fork/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/forgecode-fork/.github/workflows/sast-quick.yml
+++ b/forgecode-fork/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/pheno-cli/.github/workflows/sast-full.yml
+++ b/pheno-cli/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/pheno-cli/.github/workflows/sast-quick.yml
+++ b/pheno-cli/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-governance/.github/workflows/sast-full.yml
+++ b/phenotype-governance/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-governance/.github/workflows/sast-quick.yml
+++ b/phenotype-governance/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-infrakit/.github/workflows/sast-full.yml
+++ b/phenotype-infrakit/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-infrakit/.github/workflows/sast-quick.yml
+++ b/phenotype-infrakit/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-router-monitor/.github/workflows/sast-full.yml
+++ b/phenotype-router-monitor/.github/workflows/sast-full.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # pinned from @master
         with:
           scan-type: fs
           scan-ref: .
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail

--- a/phenotype-router-monitor/.github/workflows/sast-quick.yml
+++ b/phenotype-router-monitor/.github/workflows/sast-quick.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: trufflesecurity/trufflehog@main
+      - uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # pinned from @main
         with:
           path: ./
           extra_args: --only-verified --fail


### PR DESCRIPTION
## **User description**
## Summary

PhenoDevOps local main had 16 uncommitted `sast-{full,quick}.yml` files
across 8 sub-projects that were SHA-pinned to **fake placeholder
commits** (e.g. `bfa4b33a0e6c6c9c97c9d7e6e6f6c2d6a7c7c7c7`). These SHAs
do not resolve in the upstream repos (404 on `gh api .../commits/<sha>`).

The prior agent (or an earlier hygiene sweep) created the placeholders
but never replaced them with real SHAs. The result is workflows that
**will fail at runtime** once the broken pin is hit.

This commit replaces both placeholder SHAs with verified commits:
- `trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf`
  (2026-06-05; the same SHA PhenoMCP and PhenoSpecs use)
- `aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e`
  (2026-06-01; the most recent commit on main)

No semantic changes — same `@master` and `@main` references, just
replaced with real, verified, immutable SHAs.

## Test plan
- [ ] CI passes (the existing 5 dependabot + 1 PhenoDevOps workflow
  suite should still trigger)
- [ ] `trufflehog github --only-verified` step actually runs (not 404
  on the action reference)
- [ ] `trivy-action` step actually runs

## Cross-reference
- Related to a wider org-wide rot that several workflow-hygiene PRs
  hit: `trufflehog/actions/setup@*` references are broken because the
  `trufflehog/actions` repo is gone. This PR sidesteps that by using
  the **company-maintained** `trufflesecurity/trufflehog` (no `actions/`
  prefix) which is the working pattern.
- See `repos/worklogs/WORKFLOW_HYGIENE_20260606.md` for the full sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only third-party action pinning with no application or runtime logic changes; main risk is a bad SHA breaking CI until corrected.
> 
> **Overview**
> Across **eight** sub-projects, **SAST** workflows stop using floating **`@master`** / **`@main`** refs and pin **`aquasecurity/trivy-action`** and **`trufflesecurity/trufflehog`** to full commit SHAs (with comments noting the original branch).
> 
> In **`sast-full.yml`**, the Trivy repository scan step now uses **`bfa4b33a029b9aa80ddb784b45574c30e072c59e`** instead of **`@master`**. The full secret-scan job uses TruffleHog **`75add79b929b263dae147d2e5bcf0daf292165cf`** instead of **`@main`**.
> 
> **`sast-quick.yml`** gets the same TruffleHog pin on the PR/push secret-scan job. Scan inputs (`scan-type`, `extra_args`, etc.) and other jobs are unchanged—only the action versions are fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8bd973d90fcc19320f3711c494706183753bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Use verified pins for security scans in CI**

### What Changed
- Replaced fake placeholder commit references in secret and dependency scans with real pinned versions
- Secret scanning now points to a valid `trufflehog` commit instead of a broken branch reference
- Repository scanning now points to a valid `trivy-action` commit instead of a broken branch reference
- Applied across the affected workflow files in all listed sub-projects

### Impact
`✅ Fewer CI failures from broken scan references`
`✅ Security scans run instead of stopping at missing commits`
`✅ More reliable workflow runs across all affected repos`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
