### PR TITLE
chore(PhenoDevOps): align .vscode/settings.json with org standard

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,44 @@
+{
+  // Editor
+  "editor.formatOnSave": true,
+  "editor.rulers": [100],
+  "editor.tabSize": 4,
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  // Python
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.python",
+    "editor.formatOnSave": true,
+    "editor.rulers": [100],
+    "editor.tabSize": 4
+  },
+  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.indexing": true,
+  "python.linting.enabled": true,
+  "python.formatting.provider": "ruff",
+  "python.testing.pytestEnabled": true,
+  // Files
+  "files.exclude": {
+    "**/.git": true,
+    "**/__pycache__": true,
+    "**/*.pyc": true,
+    "**/.venv": true,
+    "**/.pytest_cache": true,
+    "**/node_modules": true,
+    "**/target": true
+  },
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/__pycache__/**": true,
+    "**/.venv/**": true,
+    "**/target/**": true
+  },
+  // Search
+  "search.exclude": {
+    "**/__pycache__": true,
+    "**/.venv": true,
+    "**/.git": true,
+    "**/target": true
+  }
+}


### PR DESCRIPTION
## **User description**
Aligns .vscode/settings.json with the org majority pattern (agent-devops-setups-style Python template: editor.formatOnSave, ms-python.python as defaultFormatter for Python, ruff as formatting provider, python.testing.pytestEnabled, ruler 100, tabSize 4, files.insertFinalNewline, files.trimTrailingWhitespace, files.exclude/watcherExclude/search.exclude for __pycache__/.pyc/.venv/.pytest_cache/node_modules/target).

The file was previously absent from this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> IDE-only configuration with no runtime, security, or deployment impact; note that root `.gitignore` lists `.vscode/`, so contributors may need an explicit add if the team intends this file to stay tracked.
> 
> **Overview**
> Introduces **`.vscode/settings.json`** for the first time in this repo, matching the org **agent-devops-setups** Python/editor template.
> 
> Shared editor defaults include **format on save**, **100-column rulers**, **tab size 4**, **final newline**, and **trim trailing whitespace**. Python is wired to **`ms-python.python`**, **Ruff** as the formatter, **basic type checking**, linting, and **pytest** as the test runner. **files.exclude**, **files.watcherExclude**, and **search.exclude** hide `.git`, `__pycache__`, `.venv`, `.pytest_cache`, `node_modules`, and `target` from the UI and search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7edee713b052d62eb94fabaf8ad3b697668d547d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add shared VS Code settings for Python development**

### What Changed
- Adds a repo-wide VS Code settings file for consistent editor behavior
- Saves Python files with formatting on save, 4-space tabs, and a 100-character ruler
- Sets Python editing tools to use Ruff, basic type checking, and pytest
- Hides common build, cache, and virtual environment folders from the file tree and search

### Impact
`✅ Consistent local editing setup`
`✅ Cleaner Python formatting on save`
`✅ Less noise in file search and explorer`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
