### PR TITLE
ci: add timeout-minutes: 10 to all jobs lacking a timeout

### DIFF
--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Sync CI/Dependabot/CodeQL Alerts To Issues
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v-latest

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,7 @@ name: Audit Workspace
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       REPOS_DIR: ${{ inputs.repos_dir }}
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,6 +26,7 @@ jobs:
   benchmark:
     name: Cargo Bench
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,7 @@ name: Generate Changelog
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       pull-requests: write
     name: Buf Lint & Breaking
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -48,6 +49,7 @@ jobs:
   rust-check:
     name: Rust Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -72,6 +74,7 @@ jobs:
   rust-build:
     name: Rust Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -88,6 +91,7 @@ jobs:
   rust-msrv:
     name: Rust MSRV (stable)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -105,6 +109,7 @@ jobs:
   rust-audit:
     name: Rust Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -121,6 +126,7 @@ jobs:
   rust-extras:
     name: Rust Extras (machete, semver, typos)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
@@ -145,6 +151,7 @@ jobs:
   rust-coverage:
     name: Rust Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -173,6 +180,7 @@ jobs:
   core-check:
     name: Core Workspace Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -195,6 +203,7 @@ jobs:
   core-build:
     name: Core Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -209,6 +218,7 @@ jobs:
   core-msrv:
     name: Core MSRV (1.86)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -223,6 +233,7 @@ jobs:
   core-docs:
     name: Core Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -237,6 +248,7 @@ jobs:
   domain-deps-lint:
     name: Domain Zero-Dep Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Validate domain crate dependencies
@@ -255,6 +267,7 @@ jobs:
   python-check:
     name: Python Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
@@ -274,6 +287,7 @@ jobs:
   python-install:
     name: Python Install
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
@@ -288,6 +302,7 @@ jobs:
   config-lint:
     name: Config Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install taplo
@@ -302,6 +317,7 @@ jobs:
     name: Conventional Commits
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,5 +16,6 @@ permissions:
   contents: read
 jobs:
   coverage:
+    timeout-minutes: 10
     uses: KooshaPari/phenotype-infrakit/.github/workflows/coverage.yml@c894caa3f54e88a83791a5a5aed9ceddec552387
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
@@ -48,6 +49,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   links:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - run: echo "Doc link check (phenotype-tooling integration)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   vitepress:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -15,6 +15,7 @@ jobs:
   capture-evidence:
     name: Capture evidence bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       BRANCH: ${{ github.ref_name }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/fr-coverage.yml
+++ b/.github/workflows/fr-coverage.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - run: echo "FR coverage check (phenotype-tooling integration)"

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   cargo-fuzz:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install Rust

--- a/.github/workflows/gate-check.yml
+++ b/.github/workflows/gate-check.yml
@@ -12,6 +12,7 @@ name: Gate Check
 jobs:
   gate-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       LANGUAGE: ${{ inputs.language }}
       CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   tfsec:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install tfsec
@@ -31,6 +32,7 @@ jobs:
 
   checkov:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install checkov

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install cargo-deny
@@ -29,6 +30,7 @@ jobs:
 
   fossa:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install FOSSA

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ name: Lint
 jobs:
   golangci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290 # v-latest

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -16,6 +16,7 @@ jobs:
   policy-gate:
     name: policy-gate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -11,6 +11,7 @@ name: Promote Package
 
 jobs:
   gate-check:
+    timeout-minutes: 10
     uses: ./.github/workflows/gate-check.yml
     with:
       language: ${{ inputs.language }}
@@ -18,6 +19,7 @@ jobs:
       risk_profile: ${{ inputs.risk_profile }}
 
   publish:
+    timeout-minutes: 10
     uses: ./.github/workflows/publish.yml
     needs: gate-check
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ name: Publish Package
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Run quality checks

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   gate-check:
+    timeout-minutes: 10
     uses: ./.github/workflows/gate-check.yml
     with:
       language: ${{ inputs.language }}
@@ -34,6 +35,7 @@ jobs:
   cyclonedx-sboms:
     name: CycloneDX SBOMs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
@@ -59,6 +61,7 @@ jobs:
   syft-spdx:
     name: Syft SPDX (workspace)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
@@ -92,6 +95,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - build-release
       - cyclonedx-sboms

--- a/.github/workflows/sast-full.yml
+++ b/.github/workflows/sast-full.yml
@@ -27,6 +27,7 @@ jobs:
   trivy-repo:
     name: Trivy Repository Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # v-latest
@@ -70,6 +71,7 @@ jobs:
   full-secrets:
     name: Full Secret Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:

--- a/.github/workflows/sast-quick.yml
+++ b/.github/workflows/sast-quick.yml
@@ -56,6 +56,7 @@ jobs:
   lint-rust:
     name: Rust Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -67,6 +68,7 @@ jobs:
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: licensefinder/license_finder_action@v2

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   cyclonedx:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,6 +28,7 @@ jobs:
   cargo-audit:
     name: Cargo Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -41,6 +42,7 @@ jobs:
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v-latest
@@ -53,6 +55,7 @@ jobs:
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
@@ -65,6 +68,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
@@ -82,6 +86,7 @@ jobs:
   python-security:
     name: Python Security
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
@@ -97,6 +102,7 @@ jobs:
   osv-scanner:
     name: OSV Scanner (Cargo.lock)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event.review.state == 'approved'
     steps:
       - name: Check self-merge eligibility

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -42,6 +42,7 @@ jobs:
   snyk-test:
     name: Snyk Vulnerability Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -126,6 +127,7 @@ jobs:
   snyk-fix:
     name: Snyk Fix (Auto-patch)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
@@ -198,6 +200,7 @@ jobs:
   dependency-check:
     name: Snyk Dependency Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
@@ -225,6 +228,7 @@ jobs:
   summary:
     name: Security Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
     needs: [snyk-test]
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   sonar:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Set up JDK 17

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   validate-specs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
@@ -139,6 +140,7 @@ jobs:
 
   comment-validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     needs: validate-specs
     steps:

--- a/.github/workflows/sync-canary.yml
+++ b/.github/workflows/sync-canary.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   sync-canary:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   trivy-fs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Run Trivy filesystem scan

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:

--- a/.github/workflows/workflow-maintenance.yml
+++ b/.github/workflows/workflow-maintenance.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   validate-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
@@ -46,6 +47,7 @@ jobs:
 
   security-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 

--- a/.github/workflows/workflow-sync.yml
+++ b/.github/workflows/workflow-sync.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   sync-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout template repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/zap-dast.yml
+++ b/.github/workflows/zap-dast.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   zap:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - name: Install ZAP


### PR DESCRIPTION
## **User description**
## Summary
- Add explicit `timeout-minutes: 10` to CI jobs that lacked a timeout, per org hygiene mandate.

## Context
Follow-up to the PhenoDevOps hygiene fan-out (tick 25 worklog). Single targeted change scoped to the timeout fix only; the broader hygiene work has already been merged via prior PRs (#201, #202, #203, #204, #205).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only hygiene with no application or secret changes; the main risk is legitimate long-running jobs timing out at 10 minutes.
> 
> **Overview**
> Adds **`timeout-minutes: 10`** at the job level across **`.github/workflows/*.yml`** wherever jobs had no explicit timeout, matching an org CI hygiene rule so runs cannot hang indefinitely on the default 6-hour limit.
> 
> Coverage spans the main **CI**, **security**, **release/publish**, **docs/deploy**, and auxiliary workflows (SAST, Snyk, SBOM, policy gates, reusable **`coverage.yml`** caller jobs, etc.). Jobs that already used other limits (e.g. **`sast-quick.yml`** 3–5 minutes, **`sast-full.yml`** CodeQL at 30 / Semgrep at 20) are unchanged except where they previously had no timeout.
> 
> **Operational note:** heavy jobs (full **`cargo test`**, CodeQL, long installs) that sometimes exceed 10 minutes may start failing with **`timed_out`** until timeouts are tuned per job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c60fa95143c2b9d42d2039903966a249ff5ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add time limits to CI jobs so stuck runs stop sooner

### What Changed
- Most workflow jobs now stop after 10 minutes instead of running indefinitely
- Reusable release, publish, coverage, and promotion workflows also get the same limit
- Existing longer limits on security scans that already had a set timeout were left as-is

### Impact
`✅ Fewer stuck CI runs`
`✅ Faster failure when a job hangs`
`✅ Shorter waits for failed checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
