### PR TITLE
chore(cliff): adopt shared template + wire adoption check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,3 +325,13 @@ jobs:
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed
         with:
           configFile: .commitlintrc.yml
+
+  check-cliff-template:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check cliff.toml adoption
+        run: ./scripts/check-cliff-template.sh

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,9 @@ rust/forge/
 # Rust build artifacts
 /target
 PhenoDevOps-wtrees/
+
+# --- Org standard additions ---
+coverage/
+.astro/
+_stub/bin/
+_stub/obj/

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,3 +1,4 @@
+# Source: https://github.com/KooshaPari/phenotype-tooling/blob/main/templates/cliff.toml
 # git-cliff configuration for phenotype-infrakit (AgilePlus monorepo)
 # https://git-cliff.org/docs/configuration
 

--- a/scripts/check-cliff-template.sh
+++ b/scripts/check-cliff-template.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# check-cliff-template.sh
+#
+# Flags repos whose cliff.toml is the canonical pattern without
+# a template-reference comment.
+#
+# Exit code 0 = OK (adopted or non-canonical)
+# Exit code 1 = WARN (canonical pattern, not adopted)
+# Exit code 2 = ERROR (no cliff.toml at all)
+set -euo pipefail
+
+if [ ! -f cliff.toml ]; then
+  echo "::error::No cliff.toml file"
+  exit 2
+fi
+
+# If Source comment is present, treat as adopted
+if grep -qE '^# Source:.*phenotype-tooling.*cliff' cliff.toml; then
+  echo "Adopted (Source comment present)"
+  exit 0
+fi
+
+# Canonical pattern detection: check for the key markers
+if grep -qF 'git-cliff.org/docs/configuration' cliff.toml \
+   && grep -qF 'conventional_commits = true' cliff.toml \
+   && grep -qF 'filter_unconventional = true' cliff.toml; then
+  echo "::warning::Canonical cliff.toml pattern without template reference. See https://github.com/KooshaPari/phenotype-tooling/blob/main/docs/cliff-adoption.md"
+  exit 1
+fi
+
+# Otherwise, OK (non-canonical, repo-specific cliff.toml)
+echo "Non-canonical cliff.toml (OK, repo-specific)"
+exit 0


### PR DESCRIPTION
## **User description**
## Summary

Adopts the shared `cliff.toml` template from
[phenotype-tooling](https://github.com/KooshaPari/phenotype-tooling/blob/main/templates/cliff.toml) (PR #118).

## Changes

- `cliff.toml`: adds the `# Source: ` traceability comment. No semantic change.
- `scripts/check-cliff-template.sh`: vendored from phenotype-tooling (33 lines, detects v1 and missing Source comment).
- `.github/workflows/ci.yml`: adds a `check-cliff-template` job that runs the check on every PR.

## CI wiring

This repo already had a `ci.yml` workflow, so the check was added as a new job in that file. The job uses `actions/checkout@v4` and runs the local script.

## Test plan

- [x] `./scripts/check-cliff-template.sh` exits 0
- [x] Local changelog generation still works (`git-cliff --dry-run`)

## Related

- Source PR: KooshaPari/phenotype-tooling#118
- DAG: FLEET_100TASK_DAG_V4.md §85 (V9-T3-4c)


___

## **CodeAnt-AI Description**
**Adopt the shared changelog template and check for drift in CI**

### What Changed
- Added a source link to `cliff.toml` so the changelog template can be traced back to the shared reference
- Added a CI check that fails when a canonical `cliff.toml` is missing the source reference
- The check also distinguishes repo-specific changelog configs and leaves them unchanged

### Impact
`✅ Clearer changelog template ownership`
`✅ Fewer template drift regressions on pull requests`
`✅ Faster detection of missing adoption comments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DevOps and changelog config only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Marks **cliff.toml** as adopted from the shared **phenotype-tooling** template by adding a `# Source:` traceability comment at the top; changelog behavior is unchanged.
> 
> Adds **scripts/check-cliff-template.sh** to enforce that repos using the canonical git-cliff pattern include that source comment (warns if missing, errors if **cliff.toml** is absent). A new **check-cliff-template** job in **ci.yml** runs this script on PRs.
> 
> **.gitignore** gains org-standard ignores for **coverage/**, **.astro/**, and **_stub/** build dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d710cca8845d23a382919193f02c43208f45de1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->