### PR TITLE
chore(PhenoDevOps): lift ahead branch chore/tick26-lift-ahead-20260611

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,9 @@ rust/forge/
 # Rust build artifacts
 /target
 PhenoDevOps-wtrees/
+
+# --- Org standard additions ---
+coverage/
+.astro/
+_stub/bin/
+_stub/obj/


### PR DESCRIPTION
Lifts the ahead work on the chore/tick26-lift-ahead-20260611 branch into main via squash merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no effect on runtime behavior, security, or deployed artifacts.
> 
> **Overview**
> Extends **`.gitignore`** with an **“Org standard additions”** block so local build and tooling output is not tracked: **`coverage/`**, **`.astro/`**, and **`_stub/bin/`** / **`_stub/obj/`**.
> 
> No application or CI logic changes appear in this diff—only ignore rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ae97ef8e8f7297f8e348a9c2f4ea0399a6dc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->