### PR TITLE
feat(agileplus-cli): adopt clap-ext (Verbosity, ConfigArg, setup_tracing)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ blake3 = "1"
 hex = "0.4"
 zstd = "0.13"
 unicode-normalization = "0.1"
+clap-ext = { git = "https://github.com/KooshaPari/clap-ext", tag = "v0.1.0" }
 [profile.dev]
 opt-level = 0
 debug = true

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -24,6 +24,7 @@ sha2.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+clap-ext.workspace = true
 anyhow.workspace = true
 similar = "2"
 

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -8,6 +8,7 @@ use std::process;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use clap_ext::prelude::{setup_tracing, ConfigArg, Verbosity};
 
 use agileplus_cli::commands::{
     branch::BranchArgs, cycle::CycleArgs, implement::ImplementArgs, module::ModuleArgs,
@@ -28,9 +29,13 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Increase verbosity (-v, -vv, -vvv)
-    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
-    verbose: u8,
+    /// Verbosity (-v, -vv, -vvv for more, -q to silence)
+    #[command(flatten)]
+    verbosity: Verbosity,
+
+    /// Optional config file (PHENOTYPE_CONFIG env var also honored)
+    #[command(flatten)]
+    config: ConfigArg,
 
     /// Path to SQLite database
     #[arg(long, global = true, default_value = ".agileplus/agileplus.db")]
@@ -77,21 +82,40 @@ enum Commands {
 async fn main() {
     let cli = Cli::parse();
 
-    // Configure logging based on verbosity
-    let log_level = match cli.verbose {
-        0 => tracing::Level::INFO,
-        1 => tracing::Level::DEBUG,
-        _ => tracing::Level::TRACE,
-    };
-    tracing_subscriber::fmt()
-        .with_max_level(log_level)
-        .with_target(false)
-        .compact()
-        .init();
+    // Configure logging via clap-ext's shared setup_tracing
+    setup_tracing(cli.verbosity.to_filter());
+    if let Some(cfg) = &cli.config.config {
+        tracing::debug!(config = %cfg.display(), "config override");
+    }
 
     if let Err(e) = run(cli).await {
         eprintln!("Error: {e:#}");
         process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn cli_parses_with_clap_ext_flattens() {
+        // Verify the new Verbosity + ConfigArg flattens parse cleanly.
+        let cli = Cli::try_parse_from(["agileplus", "--quiet", "--config", "/tmp/x.yml", "triage"])
+            .expect("parse");
+        assert!(cli.verbosity.quiet);
+        assert_eq!(cli.config.config.as_deref(), Some(std::path::Path::new("/tmp/x.yml")));
+    }
+
+    #[test]
+    fn verbosity_to_filter_default() {
+        // No flags => INFO level
+        let v = Verbosity::default();
+        assert!(matches!(
+            v.to_filter(),
+            tracing_subscriber::filter::LevelFilter::INFO
+        ));
     }
 }
 


### PR DESCRIPTION
## **User description**
Consolidates CLI boilerplate to clap-ext v0.1.0. Adopts 3 shared primitives (Verbosity, ConfigArg, setup_tracing).

## What changed

- `Cli` struct now flattens `clap_ext::prelude::Verbosity` (`-v`, `-vv`, `-vvv`, `--quiet/-q`)
- `Cli` struct now flattens `clap_ext::prelude::ConfigArg` (`--config/-c` plus `PHENOTYPE_CONFIG` env var)
- `main()` initializes logging via `clap_ext::prelude::setup_tracing()` (was hand-rolled tracing-subscriber)
- Workspace `Cargo.toml` adds `clap-ext` to `[workspace.dependencies]`

## Test results

2 new smoke tests added: `cli_parses_with_clap_ext_flattens`, `verbosity_to_filter_default`.

## Note on workspace build state

PhenoDevOps main branch workspace is in a pre-broken state (missing `axum` and `opentelemetry` in `[workspace.dependencies]`). The clap-ext changes are syntactically correct and isolated to `crates/agileplus-cli/`, but the workspace will not build until those missing workspace deps are fixed in a separate PR.

Refs: FLEET_100TASK_DAG_V4.md §86 (V9-T3-5)
clap-ext v0.1.0: https://github.com/KooshaPari/clap-ext/releases/tag/v0.1.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI parsing and tracing initialization; config is parsed but not yet consumed beyond debug logging, and behavior should match prior log levels aside from the new quiet flag.
> 
> **Overview**
> **agileplus** CLI boilerplate is moved onto shared **clap-ext** (`v0.1.0` from git), wired through the workspace and `agileplus-cli`.
> 
> The root `Cli` no longer uses a custom `verbose: u8` counter or hand-rolled `tracing_subscriber` setup. It **flattens** `Verbosity` (supports `-v`/`-vv`/`-vvv` and new **`--quiet`/`-q`**) and `ConfigArg` (**`--config`/`-c`**, plus **`PHENOTYPE_CONFIG`**). Startup logging goes through **`setup_tracing(cli.verbosity.to_filter())`**. When a config path is present, the binary only emits a **debug** line with that path—config loading behavior is unchanged elsewhere in this diff.
> 
> Two unit tests cover parsing of the new flags and default verbosity mapping to **INFO**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3fb2f8e1b57bc74752ddd4fafe619e496e7813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Adopt shared CLI flags and logging setup for `agileplus`**

### What Changed
- The CLI now supports a quiet mode with `-q` and keeps the usual `-v`, `-vv`, and `-vvv` verbosity options.
- Users can now pass a config file with `--config` or `-c`, and the `PHENOTYPE_CONFIG` environment variable is also recognized.
- Startup logging now follows the shared tracing setup used across other CLIs, and the selected config file is reported in debug logs.
- Added smoke tests to confirm the new flag parsing and default logging level.

### Impact
`✅ Quieter CI and script runs`
`✅ Easier config loading in containers`
`✅ Consistent CLI behavior across tools`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
